### PR TITLE
 🐛 Worker deployment default value fix

### DIFF
--- a/archesproject/templates/deployment-worker.yaml
+++ b/archesproject/templates/deployment-worker.yaml
@@ -34,7 +34,7 @@ spec:
               name: {{ template "arches.fullname" . }}-env
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ default .Values.image.repository .Values.worker.image.repository }}:{{ .Values.worker.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.worker.image.repository | default .Values.image.repository }}:{{ .Values.worker.image.tag | default ( .Values.image.tag | default .Chart.AppVersion ) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resourcesWorker | nindent 12 }}


### PR DESCRIPTION
## 🐛 Bug Fix

### Description

Worker deployment initContainer does not default to the correct tag value. It defaults to the chart value even though such `.Values.image.tag` exist as a value. [For more information click here](#3)

### Checklist

- [x] I have included a clear description of the bug.
- [x] I have listed the steps to reproduce the issue.
- [x] I have attached any relevant logs or screenshots.

### Who can review?

@philtweir 