### PR TITLE
feat: update rabbitmq img and update arches base to 8.1

### DIFF
--- a/archesproject/Chart.yaml
+++ b/archesproject/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: An initial Helm chart for archesproject.org software (unofficial)
 name: archesproject
 type: application
-version: 0.0.17
-appVersion: "7.6.4"
+version: 0.0.18
+appVersion: "8.1"
 keywords:
   - arches
   - heritage

--- a/archesproject/values.yaml
+++ b/archesproject/values.yaml
@@ -17,7 +17,8 @@ workerReplicaCount: 1
 staticReplicaCount: 1
 
 image:
-  repository: flaxandteal/arches
+  repository: ghcr.io/flaxandteal/arches-base
+  tag: docker-8.1.0-release
   pullPolicy: IfNotPresent
 
 worker:
@@ -30,7 +31,8 @@ worker:
 
 api:
   image:
-    repository: flaxandteal/arches
+    repository: ghcr.io/flaxandteal/arches-base
+    tag: docker-8.1.0-release
     pullPolicy: IfNotPresent
   readinessProbe:
     initialDelaySeconds: 30
@@ -123,6 +125,10 @@ couchdb:
       uuid: <YOUR_NEW_COUCHDB_UUID>
 
 rabbitmq:
+  image:
+    registry: docker.io
+    repository: rabbitmq
+    tag: "3.10.7"
   rabbitmq:
     username: user
     password: <YOUR_NEW_RABBITMQ_PASSWORD> # TODO: needs improved


### PR DESCRIPTION
## Upgrade Arches to 8.1 and update dependencies

### Changes

- **Arches image**: Updated main and API images from `flaxandteal/arches` to `ghcr.io/flaxandteal/arches-base:docker-8.1.0-release`
- **RabbitMQ image**: Switched from Bitnami's `bitnami/rabbitmq` to the official `rabbitmq:3.10.7` image (Docker Hub)
- **appVersion**: Bumped to `8.1`